### PR TITLE
replaced existing config (rather than append)

### DIFF
--- a/config/php-start.sh
+++ b/config/php-start.sh
@@ -12,7 +12,7 @@ fi
 
 if [ "$NEWRELIC_ENABLED" = true ]; then
     echo "Enabling New Relic.."
-    cat /opt/etc/newrelic.ini >> /usr/local/etc/php/conf.d/newrelic.ini
+    cat /opt/etc/newrelic.ini > /usr/local/etc/php/conf.d/newrelic.ini
     sed -i -- 's/REPLACE_WITH_REAL_KEY/'${NEWRELIC_KEY}'/g' /usr/local/etc/php/conf.d/newrelic.ini
     sed -i -- 's/REPLACE APPLICATION NAME/'${NEWRELIC_APPNAME}'/g' /usr/local/etc/php/conf.d/newrelic.ini
     sed -i -- 's/;newrelic.enabled/newrelic.enabled/g' /usr/local/etc/php/conf.d/newrelic.ini


### PR DESCRIPTION
fixed error where `PHP Warning:  Module 'newrelic' already loaded in Unknown on line 0` would be shown when PHP run from the command line
